### PR TITLE
fix typo of address key for marketData

### DIFF
--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -56,7 +56,7 @@ export async function getMarketData(
     throw 'Market account is unavailable';
   }
   let marketData = {
-    adress: marketKey,
+    address: marketKey,
     coinMintKey: new PublicKey(marketAccountInfo.data.slice(53, 85)),
     coinVaultKey: new PublicKey(marketAccountInfo.data.slice(117, 149)),
     coinLotSize: new Numberu64(


### PR DESCRIPTION
According to the type definition of `MarketData`, `adress` should be `address`.